### PR TITLE
Add support for automatically cleaning indexes

### DIFF
--- a/config.json
+++ b/config.json
@@ -43,6 +43,14 @@
       }
     }
   },
+  "gc": {
+    "test-": {
+      "keep": 1
+    },
+    "logs-": {
+      "keep": 5
+    }
+  },
   "mappings": {
     "test": {
       "fields": {

--- a/lib/punt/cluster.go
+++ b/lib/punt/cluster.go
@@ -124,10 +124,9 @@ func (c *Cluster) Run() error {
 }
 
 func (c *Cluster) gcIndexes() {
-	ticker := time.NewTicker(time.Second * 5)
-	for {
-		<-ticker.C
+	ticker := time.NewTicker(time.Minute * 15)
 
+	for range ticker.C {
 		for prefix, gcConfig := range c.State.Config.GC {
 			GCIndexes(c.esClient, prefix, gcConfig)
 		}

--- a/lib/punt/config.go
+++ b/lib/punt/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	Alerts        map[string]AlertConfig   `json:"alerts"`
 	Actions       map[string]ActionConfig  `json:"actions"`
 	ControlSocket ControlSocketConfig      `json:"control_socket"`
+	GC            map[string]GCConfig      `json:"gc"`
 }
 
 func LoadConfig(path string) (*Config, error) {

--- a/lib/punt/gc.go
+++ b/lib/punt/gc.go
@@ -1,0 +1,41 @@
+package punt
+
+import (
+	"context"
+	"log"
+	"sort"
+
+	"gopkg.in/olivere/elastic.v5"
+)
+
+type GCConfig struct {
+	Keep int `json:"keep"`
+}
+
+func GCIndexes(esClient *elastic.Client, prefix string, config GCConfig) {
+	ctx := context.Background()
+	indexes, err := elastic.NewIndicesGetService(esClient).Index(prefix + "*").Do(ctx)
+
+	if err != nil {
+		log.Printf("[GC] ERROR: failed to get list of indexes; %v", err)
+		return
+	}
+
+	if len(indexes) <= config.Keep {
+		return
+	}
+
+	sortedIndexNames := make([]string, 0)
+	for key, _ := range indexes {
+		sortedIndexNames = append(sortedIndexNames, key)
+	}
+	sort.Strings(sortedIndexNames)
+
+	toDelete := sortedIndexNames[:config.Keep]
+
+	log.Printf("[GC] Deleting the following indexes for `%v`: %v", prefix, toDelete)
+	_, err = elastic.NewIndicesDeleteService(esClient).Index(toDelete).Do(ctx)
+	if err != nil {
+		log.Printf("[GC] ERROR: failed to delete indexes (%v): %v", toDelete, err)
+	}
+}


### PR DESCRIPTION
This PR adds support for a [curator](https://github.com/elastic/curator)-esq feature, allowing us to prune or GC indexes. The current behavior is _very_ naive and just lets you select a maximum number of indexes to keep per pattern, but it should suffice for replacing our current curator usage.