### PR TITLE
Switch Kafka library and add ticks

### DIFF
--- a/lib/punt/state.go
+++ b/lib/punt/state.go
@@ -58,14 +58,18 @@ func (s *State) Run() {
 	log.Printf("Attempting to start Punt")
 
 	for _, cluster := range s.Clusters {
+		log.Printf("Starting cluster: %s", cluster.Name)
 		cluster.Run()
 	}
+
+	log.Printf("Done starting clusters")
 
 	if s.Config.ControlSocket.Enabled {
 		cs, err := NewControlSocket(s, s.Config.ControlSocket.Bind)
 		if err != nil {
 			log.Printf("Failed to create control socket: %v", err)
 		} else {
+			log.Printf("Created control socket")
 			go cs.Run()
 		}
 	}


### PR DESCRIPTION
This adds some output every so often to show which partitions this
consumer is processing as well as what the message volume is.

This diff also temporarily switches to a forked version of the kafka-go
library to pull in a fix when consumers are too slow and falling off the
front.